### PR TITLE
Multiple parallel browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,29 +77,17 @@ The tests in this repo are run on BrowserStack real device/browser using various
   set BROWSERSTACK_ACCESS_KEY=<browserstack-access-key>
   ```
   
-### Run a specific test
+
+### Run the entire test suite in parallel
 
 - How to run the test?
 
-  To run a specific test scenario, use the command below:
+  To run the entire test suite parallely in browserstack, you will require [pabot dependency](https://pabot.org/).
+
+  Use the following command:
   
   ```sh
-  robot ./test/sample_test.robot
-  ```
-
-- Output
-
-  This run profile executes the specific test scenario in browserstack on the platforms configured in your config file.
-
-
-### Run the entire test suite
-
-- How to run the test?
-
-  To run the entire test suite parallely in browserstack, you will require [pabot dependency](https://pabot.org/)  use the following command:
-  
-  ```sh
-  pabot --testlevelsplit --processes 3 ./test/sample_test.robot
+  pabot --pabotlib --testlevelsplit --processes 3 ./test/sample_test.robot
   ```
   You can also use the other combinations as described in [pabot](https://pabot.org/) to run your tests parallely. 
 
@@ -110,7 +98,13 @@ The tests in this repo are run on BrowserStack real device/browser using various
   
 --- 
 
-### Run tests on BrowserStack which need Local Environment access
+### Run tests in Parallel on BrowserStack which need Local Environment access
+
+- How to run the test?
+
+  To run the entire test suite parallely in browserstack, you will require [pabot dependency](https://pabot.org/) and [pabotlib dependecy](https://pabot.org/PabotLib.html), PabotLib helps in parallel execution with pabot. These allow control to when and where a keyword will be executed.
+  -  Run Setup Only Once is used for starting the local testing connection
+  -  Run On Last Process is used for killing the local testing connection
 
   **Using Language Bindings**
 
@@ -119,10 +113,7 @@ The tests in this repo are run on BrowserStack real device/browser using various
   pip install browserstack-local
   ```
   ```sh
-  robot ./test/sample_local_test.robot
-  ```
-  ```sh
-  pabot --testlevelsplit --processes 3 ./test/sample_local_test.robot
+  pabot --pabotlib --testlevelsplit --processes 2 ./test/sample_local_test.robot   
   ```
 
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The tests in this repo are run on BrowserStack real device/browser using various
 
   To run the entire test suite parallely in browserstack, you will require [pabot dependency](https://pabot.org/) and [pabotlib dependecy](https://pabot.org/PabotLib.html), PabotLib helps in parallel execution with pabot. These allow control to when and where a keyword will be executed.
   -  Run Setup Only Once is used for starting the local testing connection
-  -  Run On Last Process is used for killing the local testing connection
+  -  Run Teardown Only Once is used for killing the local testing connection
 
   **Using Language Bindings**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 robotframework-browser
-robotframework==6.0
-robotframework-pabot==2.13.0
+robotframework
+robotframework-pabot
 browserstack-local
+playwright

--- a/test/CustomLib.py
+++ b/test/CustomLib.py
@@ -17,6 +17,7 @@ class CustomLib:
     'buildTag': 'Regression',
     'resolution': '1280x1024',
     'browserstack.local': 'true',
+    'browserstack.localIdentifier': 'local_connection_name',
     'browserstack.playwrightVersion': '1.latest',
     'client.playwrightVersion': '1.latest',
     'browserstack.debug': 'true',  # enabling visual logs
@@ -61,7 +62,7 @@ class CustomLib:
     def startLocalTunnel(self):
         global bs_local
         bs_local = Local()
-        bs_local_args = { "key": "1pkpXahTJTDkhMeAhvfu" }
+        bs_local_args = { "key": os.environ['BROWSERSTACK_ACCESS_KEY'], "localIdentifier": "local_connection_name"}
         bs_local.start(**bs_local_args)
 
     

--- a/test/CustomLib.py
+++ b/test/CustomLib.py
@@ -2,24 +2,21 @@ from browserstack.local import Local
 import json
 import urllib.parse
 import subprocess
-import os
-
+import os 
 
 class CustomLib:
+    desired_cap = None
+    bs_local = None
+    
     desired_cap = {
-    'os': 'osx',
-    'os_version': 'catalina',
-    'browser': 'chrome',  # allowed browsers are `chrome`, `edge`, `playwright-chromium`, `playwright-firefox` and `playwright-webkit`
-    'browser_version': 'latest', # this capability is valid only for branded `chrome` and `edge` browsers and you can specify any browser version like `latest`, `latest-beta`, `latest-1` and so on.
+    'browser_version': 'latest',
     'browserstack.username': os.environ['BROWSERSTACK_USERNAME'],
     'browserstack.accessKey': os.environ['BROWSERSTACK_ACCESS_KEY'],
-    'browserstack.geoLocation': 'FR',
     'project': 'BStack Project',
     'build': 'browserstack-build-1',
     'buildTag': 'Regression',
     'resolution': '1280x1024',
     'browserstack.local': 'true',
-    'browserstack.localIdentifier': 'local_connection_name',
     'browserstack.playwrightVersion': '1.latest',
     'client.playwrightVersion': '1.latest',
     'browserstack.debug': 'true',  # enabling visual logs
@@ -32,9 +29,26 @@ class CustomLib:
     }
 
 
-    def createCdpUrl(self):
+    def createCdpUrl(self,browser):
         clientPlaywrightVersion = str(subprocess.getoutput('playwright --version')).strip().split(" ")[1]
         CustomLib.desired_cap['client.playwrightVersion'] = clientPlaywrightVersion
+        if(browser=='chrome'):
+            CustomLib.desired_cap['os']='Windows'
+            CustomLib.desired_cap['os_version']='11'
+            CustomLib.desired_cap['browser']='chrome'
+    
+            
+                
+        elif(browser=='firefox'):
+            CustomLib.desired_cap['os']='OS X'
+            CustomLib.desired_cap['os_version']='Ventura'
+            CustomLib.desired_cap['browser']='playwright-firefox'
+            
+        else:
+            CustomLib.desired_cap['os']='OS X'
+            CustomLib.desired_cap['os_version']='Ventura'
+            CustomLib.desired_cap['browser']='playwright-webkit'
+        
         cdpUrl = 'wss://cdp.browserstack.com/playwright?caps=' + urllib.parse.quote(json.dumps(CustomLib.desired_cap))
         print(cdpUrl)
         return cdpUrl
@@ -45,16 +59,14 @@ class CustomLib:
         return platformDetails
     
     def startLocalTunnel(self):
-        # Creates an instance of Local
-        self.bs_local = Local()
-        # You can also set an environment variable - "BROWSERSTACK_ACCESS_KEY".
-        bs_local_args = { "key": os.environ['BROWSERSTACK_ACCESS_KEY'], "forcelocal": "true" }
-        # Starts the Local instance with the required arguments
-        self.bs_local.start(**bs_local_args)
-        # Check if BrowserStack local instance is running
-        print("BrowserStackLocal running: " + str(self.bs_local.isRunning()))
+        global bs_local
+        bs_local = Local()
+        bs_local_args = { "key": "1pkpXahTJTDkhMeAhvfu" }
+        bs_local.start(**bs_local_args)
+
     
     def stopLocalTunnel(self):
-        self.bs_local.stop()
-
+        global bs_local
+        if bs_local is not None:
+            bs_local.stop()
     

--- a/test/sample_local_test.robot
+++ b/test/sample_local_test.robot
@@ -1,29 +1,30 @@
 *** Settings ***
 Documentation       Playwright template.
 
-Library             ./CustomLib.py
-Library             String
+Library    ./CustomLib.py
+Library    String
 Library     Browser    jsextension=${EXECDIR}/test/browserstackExecutor.js
-Suite Setup    CustomLib.startLocalTunnel
-Suite Teardown    CustomLib.stopLocalTunnel
+Library     pabot.PabotLib
+Suite Setup    Run Setup Only Once    CustomLib.startLocalTunnel
+Suite Teardown    Run On Last Process    CustomLib.stopLocalTunnel
 
-*** Tasks ***
-Sample Local task 1
-    ${cdpURL}=    Create Cdp Url
+*** Test Cases ***
+Sample Local Test 1
+    ${cdpURL}=    createCdpUrl    chrome
     ${platfromDetails}=    getPlatformDetails
     Connect To Browser    ${cdpURL}
-    New Page    http://localhost:45454/
-    ${assert}=    Get Title    ==    "BrowserStack Local"
+    New Page    http://bs-local.com:45454
+    ${assert}    Run Keyword And Warn On Failure    Get Title    ==    BrowserStack Local
     SetStatus    ${assert[0]}    ${assert[1]}
     ${sessionName} =   Catenate    ${TEST_NAME}   ${platfromDetails}   
     SetSessionName    ${sessionName}
     Close Browser
-Sample Local task 2
-    ${cdpURL}=    Create Cdp Url
+Sample Local Test 2
+    ${cdpURL}=    createCdpUrl    webkit
     ${platfromDetails}=    getPlatformDetails
     Connect To Browser    ${cdpURL}
-    New Page    http://localhost:45454/
-    ${assert}=    Get Title    ==    "BrowserStack Local"
+    New Page    http://bs-local.com:45454
+    ${assert}    Run Keyword And Warn On Failure    Get Title    ==    BrowserStack Local
     SetStatus    ${assert[0]}    ${assert[1]}
     ${sessionName} =   Catenate    ${TEST_NAME}   ${platfromDetails}   
     SetSessionName    ${sessionName}

--- a/test/sample_local_test.robot
+++ b/test/sample_local_test.robot
@@ -6,7 +6,7 @@ Library    String
 Library     Browser    jsextension=${EXECDIR}/test/browserstackExecutor.js
 Library     pabot.PabotLib
 Suite Setup    Run Setup Only Once    CustomLib.startLocalTunnel
-Suite Teardown    Run On Last Process    CustomLib.stopLocalTunnel
+Suite Teardown    Run Teardown Only Once    CustomLib.stopLocalTunnel
 
 *** Test Cases ***
 Sample Local Test 1

--- a/test/sample_test.robot
+++ b/test/sample_test.robot
@@ -6,7 +6,7 @@ Library             String
 Library     Browser    jsextension=${EXECDIR}/test/browserstackExecutor.js
 Library     pabot.PabotLib
 Suite Setup    Run Setup Only Once    CustomLib.startLocalTunnel
-Suite Teardown    Run On Last Process    CustomLib.stopLocalTunnel
+Suite Teardown    Run Teardown Only Once    CustomLib.stopLocalTunnel
 
 *** Test Cases ***
 Sample Test 1

--- a/test/sample_test.robot
+++ b/test/sample_test.robot
@@ -4,10 +4,14 @@ Documentation       Playwright template.
 Library             ./CustomLib.py
 Library             String
 Library     Browser    jsextension=${EXECDIR}/test/browserstackExecutor.js
+Library     pabot.PabotLib
+Suite Setup    Run Setup Only Once    CustomLib.startLocalTunnel
+Suite Teardown    Run On Last Process    CustomLib.stopLocalTunnel
 
-*** Tasks ***
-Sample task 1
-        ${cdpURL}=    Create Cdp Url
+*** Test Cases ***
+Sample Test 1
+        ${cdpURL}=    createCdpUrl    chrome
+        Log To Console    ${cdpURL}
         ${platfromDetails}=    getPlatformDetails
         Connect To Browser    ${cdpURL}
         New Page    https://bstackdemo.com/
@@ -18,20 +22,9 @@ Sample task 1
         SetSessionName    ${sessionName}
         Close Browser
     
-Sample task 2-FAILING
-        ${cdpURL}=    Create Cdp Url
-        ${platfromDetails}=    getPlatformDetails
-        Connect To Browser    ${cdpURL}
-        New Page    https://bstackdemo.com/
-        Click    xpath=//*[@id="1"]/div[4]
-        ${assert}    Run Keyword And Warn On Failure    Get Element Count    xpath=//*[@id="__next"]/div/div/div[2]/div[2]/div[2]    ==    5
-        SetStatus    ${assert[0]}    ${assert[1]}
-        ${sessionName} =   Catenate    ${TEST_NAME}   ${platfromDetails}   
-        SetSessionName    ${sessionName}
-        Close Browser
-
-Sample task 3-PASSING
-        ${cdpURL}=    Create Cdp Url
+Sample Test 2
+        ${cdpURL}=    createCdpUrl    firefox
+        Log To Console    ${cdpURL}
         ${platfromDetails}=    getPlatformDetails
         Connect To Browser    ${cdpURL}
         New Page    https://bstackdemo.com/
@@ -40,4 +33,17 @@ Sample task 3-PASSING
         SetStatus    ${assert[0]}    ${assert[1]}
         ${sessionName} =   Catenate    ${TEST_NAME}   ${platfromDetails}   
         SetSessionName    ${sessionName}
-        Close Browser    ALL        
+        Close Browser
+
+Sample task 3
+        ${cdpURL}=    createCdpUrl    safari
+        Log To Console    ${cdpURL}
+        ${platfromDetails}=    getPlatformDetails
+        Connect To Browser    ${cdpURL}
+        New Page    https://bstackdemo.com/
+        Click    xpath=//*[@id="1"]/div[4]
+        ${assert}    Run Keyword And Warn On Failure    Get Element Count    xpath=//*[@id="__next"]/div/div/div[2]/div[2]/div[2]    ==    1
+        SetStatus    ${assert[0]}    ${assert[1]}
+        ${sessionName} =   Catenate    ${TEST_NAME}   ${platfromDetails}   
+        SetSessionName    ${sessionName}
+        Close Browser        


### PR DESCRIPTION
Build Name should be browserstack-build-1  ✔️
Session name includes platform combination (Format= Sample task 1 osx ventura chrome latest) ✔️
Meaningful Status Reason ✔️
Markin Test Status ✔️
Renames robot files (sample_test.robot, sample_local_test.robot) ✔️
Stable local execution ✔️
Combinations as per the guidelines (Chrome, Firefox, Webkit) ✔️ ✔️ ✔️
Removed Single, Only Parallel & Local ✔️
No Failure scenarios, Only Passing cases ✔️

Note : `geoLocation` capability isn't supported with playwright bundled browsers, hence removed it.
